### PR TITLE
Fix some build error in new 4.x kernel and gcc version.

### DIFF
--- a/consistent-offsets.c
+++ b/consistent-offsets.c
@@ -21,7 +21,6 @@
  */
 
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -29,6 +28,7 @@
 #include <sys/timex.h>
 #include <string.h>
 #include <signal.h>
+#include <unistd.h>
 
 extern char *optarg;
 

--- a/ntp-converge.c
+++ b/ntp-converge.c
@@ -32,7 +32,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
-
+#include <unistd.h>
+#include <sys/wait.h>
 
 #define NSEC_PER_SEC 		1000000000LL
 


### PR DESCRIPTION
Test on kernel-4.18.0-20.el8.x86_64, gcc-8.2.1-3.el8.x86_64, glibc-2.28-17.el8.x86_64

cc -O3 -Wl,-no-as-needed  -lrt -lpthread  consistent-offsets.c   -o consistent-offsets
consistent-offsets.c: In function ‘test_offsets’:
consistent-offsets.c:132:4: warning: implicit declaration of function ‘usleep’; did you mean ‘fseek’? [-Wimplicit-function-declaration]
    usleep(NSEC_PER_SEC/1000);
    ^~~~~~
    fseek
consistent-offsets.c: In function ‘main’:
consistent-offsets.c:151:16: warning: implicit declaration of function ‘getopt’; did you mean ‘getsubopt’? [-Wimplicit-function-declaration]
  while ((opt = getopt(argc, argv, "t:c:"))!=-1) {
                ^~~~~~
                getsubopt
cc -O3 -Wl,-no-as-needed  -lrt -lpthread  leap-a-day.c   -o leap-a-day
cc -O3 -Wl,-no-as-needed  -lrt -lpthread  leapcrash.c   -o leapcrash

cc -O3 -Wl,-no-as-needed  -lrt -lpthread  ntp-converge.c   -o ntp-converge
ntp-converge.c: In function ‘run_driftlog’:
ntp-converge.c:112:8: warning: implicit declaration of function ‘fork’ [-Wimplicit-function-declaration]
  pid = fork();
        ^~~~
ntp-converge.c: In function ‘generate_ntp_conf’:
ntp-converge.c:168:2: warning: implicit declaration of function ‘write’; did you mean ‘fwrite’? [-Wimplicit-function-declaration]
  write(fd, buf, strlen(buf));
  ^~~~~
  fwrite
ntp-converge.c:170:2: warning: implicit declaration of function ‘close’; did you mean ‘pclose’? [-Wimplicit-function-declaration]
  close(fd);
  ^~~~~
  pclose
ntp-converge.c: In function ‘cleanup_conf’:
ntp-converge.c:178:2: warning: implicit declaration of function ‘unlink’; did you mean ‘unix’? [-Wimplicit-function-declaration]
  unlink(CONF_FILE);
  ^~~~~~
  unix
ntp-converge.c: In function ‘main’:
ntp-converge.c:200:16: warning: implicit declaration of function ‘getopt’; did you mean ‘getsubopt’? [-Wimplicit-function-declaration]
  while ((opt = getopt(argc, argv, "s:f:o:r:"))!=-1) {
                ^~~~~~
                getsubopt
ntp-converge.c:234:6: warning: implicit declaration of function ‘getuid’; did you mean ‘getenv’? [-Wimplicit-function-declaration]
  if (getuid()) {
      ^~~~~~
      getenv
ntp-converge.c:257:2: warning: implicit declaration of function ‘waitpid’ [-Wimplicit-function-declaration]
  waitpid(pid, 0,0);
  ^~~~~~~

Signed-off-by: Qiao Zhao <qiaozqjhsy@gmail.com>